### PR TITLE
Implement -k switch to use self signed certificates, cli parameters cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Options:
   -d, --devices   File location of device list (must end with .json).
   -g, --password  Gateway password (to enable gateway light change)
   -h, --help      Show help
-  -l, --logging   possiblevalues: "error", "warn","info","debug"
-                  [default: "info"]
+  -l, --logging   Logging level  [choices: "error", "warn", "info", "debug"] [default: "info"]
   -m, --mqtt      mqtt broker url. See https://github.com/svrooij/node-xiaomi2mqtt#mqtt-url
                   [default: "mqtt://127.0.0.1"]
+  -k, --insecure  accept self singed-certificates when using TLS. See https://github.com/mqttjs/MQTT.js#mqttclientstreambuilder-options  
+                  [boolean] [default: false]
   -n, --name      instance name. used as mqtt client id and as topic prefix
                   [default: "xiaomi"]
   --version       Show version number

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -27,13 +27,17 @@ function start () {
     })
   }
 
-  const mqttOptions = {
+  let mqttOptions = {
     will: {
       topic: config.name + '/connected',
       message: 0,
       qos: 0,
       retain: true
     }
+  }
+
+  if (config.insecure) {
+    mqttOptions.rejectUnauthorized = false
   }
 
   mqttClient = mqtt.connect(config.mqtt, mqttOptions)

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -27,17 +27,14 @@ function start () {
     })
   }
 
-  let mqttOptions = {
+  const mqttOptions = {
     will: {
       topic: config.name + '/connected',
       message: 0,
       qos: 0,
       retain: true
-    }
-  }
-
-  if (config.insecure) {
-    mqttOptions.rejectUnauthorized = false
+    },
+    rejectUnauthorized = !config.insecure
   }
 
   mqttClient = mqtt.connect(config.mqtt, mqttOptions)

--- a/src/config.js
+++ b/src/config.js
@@ -4,24 +4,30 @@ const config = require('yargs')
     .describe('d', 'File location of device list (must end with .json).')
     .describe('g', 'Gateway password (to enable gateway light change)')
     .describe('h', 'Show this help')
-    .describe('l', 'possiblevalues: "error", "warn","info","debug"')
+    .describe('l', 'Logging level')
     .describe('m', 'mqtt broker url. See https://github.com/mqttjs/MQTT.js#connect-using-a-url')
+    .describe('k', 'accept self singed-certificates when using TLS. See https://github.com/mqttjs/MQTT.js#mqttclientstreambuilder-options')
     .describe('n', 'instance name. used as mqtt client id and as topic prefix')
+    .boolean('k')
     .alias({
       d: 'devices',
       g: 'password',
       h: 'help',
       l: 'logging',
       m: 'mqtt',
+      k: 'insecure',
       n: 'name'
     })
+    .choices('l', ['error', 'warn', 'info', 'debug'])
     .default({
       l: 'info',
       m: 'mqtt://127.0.0.1',
+      k: false,
       n: 'xiaomi'
     })
     .version()
     .help('help')
+    .wrap(null)
     .argv
 
 module.exports = config


### PR DESCRIPTION
This PR implements `-k` command line switch (-k inspired by cURL) in order to connect to a mqtt broker with TLS and self signed certificates (or certificate signed by a non trusted CA by default)

As per [mqtt.Client(streamBuilder, options)](https://www.npmjs.com/package/mqtt#mqttclientstreambuilder-options) it is done by passing `rejectUnauthorized: false` as an added mqtt connectio option. Defaults to false.

Also cleaned up a bit `-l` logging option adding proper `.choices` in `config.js`
`-h` and Readme changed accordingly